### PR TITLE
Support for SSL/one thread per connection, HTTP/OPTIONS and protecting request_handlers

### DIFF
--- a/luna/private/server_impl.cpp
+++ b/luna/private/server_impl.cpp
@@ -146,6 +146,12 @@ static request_method method_str_to_enum_(const char *method_str)
         return request_method::DELETE;
     }
 
+    if (!std::strcmp(method_str, OPTIONS))
+    {
+        return request_method::OPTIONS;
+    }
+
+
     return request_method::UNKNOWN;
 }
 
@@ -175,6 +181,11 @@ static MHD_ValueKind method_to_value_kind_enum_(request_method method)
 ///////////////////////////
 
 server::server_impl::server_impl() :
+        lock_(),
+        cv_(),
+        in_callback_(0),
+        use_ssl_(false),
+        use_thread_per_connection_(false),
         daemon_{nullptr},
         error_handler_callback_{default_error_handler_callback_},
         accept_policy_callback_{default_accept_policy_callback_},
@@ -195,7 +206,20 @@ void server::server_impl::start()
     }
     options[idx] = {MHD_OPTION_END, 0, nullptr};
 
-    daemon_ = MHD_start_daemon(MHD_USE_POLL_INTERNALLY,
+    unsigned int flags = 0;
+    if (use_ssl_)
+    {
+        flags |= MHD_USE_SSL;
+    }
+    if (use_thread_per_connection_)
+    {
+        flags |= MHD_USE_THREAD_PER_CONNECTION | MHD_USE_POLL;
+    }
+    else
+    {
+        flags |= MHD_USE_POLL_INTERNALLY;
+    }
+    daemon_ = MHD_start_daemon(flags,
                                port_,
                                access_policy_callback_shim_, this,
                                access_handler_callback_shim_, this,
@@ -247,6 +271,8 @@ server::request_handler_handle server::server_impl::handle_request(request_metho
                                          std::regex &&path,
                                          server::endpoint_handler_cb callback)
 {
+    std::unique_lock<std::mutex> ulock(lock_);
+    cv_.wait(ulock, [this]{return !in_callback_;});
     return std::make_pair(method, request_handlers_[method].insert(std::end(request_handlers_[method]), std::make_pair(std::move(path), callback)));
 }
 
@@ -254,6 +280,8 @@ server::request_handler_handle server::server_impl::handle_request(request_metho
                                          const std::regex &path,
                                          server::endpoint_handler_cb callback)
 {
+    std::unique_lock<std::mutex> ulock(lock_);
+    cv_.wait(ulock, [this]{return !in_callback_;});
     return std::make_pair(method, request_handlers_[method].insert(std::end(request_handlers_[method]), std::make_pair(path, callback)));
 }
 
@@ -261,6 +289,8 @@ void server::server_impl::remove_request_handler(request_handler_handle item)
 {
     //TODO this is expensive. Find a better way to store this stuff.
     //TODO validate we are receiving a valid iterator!!
+    std::unique_lock<std::mutex> ulock(lock_);
+    cv_.wait(ulock, [this]{return !in_callback_;});
     request_handlers_[item.first].erase(item.second);
 }
 
@@ -331,6 +361,7 @@ int server::server_impl::access_handler_callback_(struct MHD_Connection *connect
     LOG_DEBUG(std::string{"Received request for "} + method_str + " " + url_str);
 
     //iterate through the handlers. Could stand being parallelized, I suppose?
+    std::unique_lock<std::mutex> ulock(lock_);
     for (const auto &handler_pair : request_handlers_[method])
     {
         std::smatch pieces_match;
@@ -352,7 +383,11 @@ int server::server_impl::access_handler_callback_(struct MHD_Connection *connect
             response response;
             try
             {
+		in_callback_++;
+		ulock.unlock();
                 response = callback({matches, query_params, header, con_info->body});
+		ulock.lock();
+		in_callback_--;
             }
             //TODO there is surely a more robust way to do this;
             catch (const std::exception &e)
@@ -390,9 +425,18 @@ int server::server_impl::access_handler_callback_(struct MHD_Connection *connect
             }
 
             //else render success
-            return render_response_(start, response, connection, url_str, method_str);
+            if (response.headers.size())
+            {
+                return render_response_(start, response, connection, url_str, method_str, response.headers);
+            }
+            else
+            {
+                return render_response_(start, response, connection, url_str, method_str);
+            }
         }
     }
+    ulock.unlock();
+    cv_.notify_all();
 
     /* unsupported HTTP method */
     return render_error_(start, {404}, connection, url, method_str);
@@ -415,8 +459,8 @@ int server::server_impl::render_response_(const std::chrono::system_clock::time_
         MHD_add_response_header(mhd_response, header.first.c_str(), header.second.c_str());
     }
 
-    auto ret = MHD_queue_response(connection, response.status_code, mhd_response);
     MHD_add_response_header(mhd_response, MHD_HTTP_HEADER_CONTENT_TYPE, response.content_type.c_str());
+    auto ret = MHD_queue_response(connection, response.status_code, mhd_response);
 
     auto end = std::chrono::system_clock::now();
 
@@ -588,6 +632,16 @@ size_t server::server_impl::unescaper_callback_shim_(void *cls, struct MHD_Conne
 
 
 ///// options setting
+
+void server::server_impl::set_option(server::use_ssl value)
+{
+    use_ssl_ = bool(value);
+}
+
+void server::server_impl::set_option(server::use_thread_per_connection value)
+{
+    use_thread_per_connection_ = bool(value);
+}
 
 void server::server_impl::set_option(const server::mime_type &mime_type)
 {

--- a/luna/private/server_impl.h
+++ b/luna/private/server_impl.h
@@ -12,6 +12,8 @@
 #include <cstring>
 #include <iostream>
 #include <chrono>
+#include <mutex>
+#include <condition_variable>
 
 
 namespace luna
@@ -22,6 +24,7 @@ const auto POST = "POST";
 const auto PUT = "PUT";
 const auto PATCH = "PATCH";
 const auto DELETE = "DELETE";
+const auto OPTIONS = "OPTIONS";
 
 
 class server::server_impl
@@ -46,6 +49,10 @@ public:
     server::request_handler_handle handle_request(request_method method, const std::regex &path, endpoint_handler_cb callback);
     void remove_request_handler(request_handler_handle item);
 
+
+    void set_option(use_ssl value);
+
+    void set_option(use_thread_per_connection value);
 
     void set_option(const mime_type &mime_type);
 
@@ -106,7 +113,14 @@ public:
 //    void set_option(notify_connection value);
 
 private:
+    std::mutex lock_;
+    std::condition_variable cv_;
+    uint32_t in_callback_;
     std::map<request_method, server::request_handlers> request_handlers_;
+
+    bool use_ssl_;
+
+    bool use_thread_per_connection_;
 
     uint16_t port_;
 

--- a/luna/server.cpp
+++ b/luna/server.cpp
@@ -41,6 +41,16 @@ void server::server_impl_deleter::operator()(server::server_impl *ptr) const
 { delete ptr; }
 
 
+void server::set_option_(use_ssl value)
+{
+    impl_->set_option(value);
+}
+
+void server::set_option_(use_thread_per_connection value)
+{
+    impl_->set_option(value);
+}
+
 void server::set_option_(mime_type mime_type)
 {
     impl_->set_option(mime_type);

--- a/luna/server.h
+++ b/luna/server.h
@@ -21,6 +21,10 @@ class server
 public:
 
     // configuration parameters
+    MAKE_BOOL_LIKE(use_ssl);
+
+    MAKE_BOOL_LIKE(use_thread_per_connection);
+
     MAKE_UINT16_T_LIKE(port);
 
     MAKE_STRING_LIKE(mime_type);
@@ -145,6 +149,10 @@ private:
         set_options_(LUNA_FWD(ts)...);
     }
 
+
+    void set_option_(use_ssl value);
+
+    void set_option_(use_thread_per_connection value);
 
     void set_option_(mime_type mime_type);
 

--- a/luna/types.h
+++ b/luna/types.h
@@ -99,6 +99,7 @@ struct request
 struct response
 {
     luna::status_code status_code;
+    request_headers headers;
     std::string content_type;
     std::string content;
 
@@ -117,15 +118,35 @@ struct response
     response(::luna::status_code status_code) : status_code{status_code}
     { }
 
+    response(::luna::status_code status_code, const ::luna::request_headers& headers) : status_code{status_code}, headers{headers}
+    { }
+
     response(::luna::status_code status_code, std::string content) : status_code{status_code}, content{content}
+    { }
+
+    response(::luna::status_code status_code, const ::luna::request_headers& headers, std::string content) : status_code{status_code}, headers{headers}, content{content}
     { }
 
     response(::luna::status_code status_code, std::string content_type, std::string content) :
             status_code{status_code}, content_type{content_type}, content{content}
     { }
 
+    response(::luna::status_code status_code, const ::luna::request_headers& headers, std::string content_type, std::string content) :
+            status_code{status_code}, headers{headers}, content_type{content_type}, content{content}
+    { }
+
     // default success responses
+    response(const ::luna::request_headers& headers, std::string content) : status_code{0}, headers{headers}, content_type{default_mime_type}, content{content}
+    { }
+
+    response(const ::luna::request_headers& headers) : status_code{0}, headers{headers}
+    { }
+
     response(std::string content) : status_code{0}, content_type{default_mime_type}, content{content}
+    { }
+
+    response(const ::luna::request_headers& headers, std::string content_type, std::string content) :
+            status_code{0}, headers{headers}, content_type{content_type}, content{content}
     { }
 
     response(std::string content_type, std::string content) :
@@ -150,9 +171,9 @@ enum class request_method
     PUT,
     PATCH,
     DELETE,
+    OPTIONS,
     //Yes, there are more than these. Later, though. Later.
     //HEAD,
-    //OPTIONS,
 };
 
 


### PR DESCRIPTION
- Add support for using SSL, one thread per connection options
- Add support for HTTP/OPTIONS handling
- Lock request_handlers as necessary to avoid corruption during
iteration