### PR TITLE
Reduce number of layers created by Dockerfile

### DIFF
--- a/examples/project_template/Dockerfile
+++ b/examples/project_template/Dockerfile
@@ -6,10 +6,10 @@ ENV PORT 8080
 EXPOSE 8080
 WORKDIR /app
 ADD . /app
-RUN sudo chown -R conan .
-RUN conan --version
-RUN conan install .
-RUN conan profile show default
-RUN cmake .
-RUN cmake --build .
+RUN sudo chown -R conan . && \
+	conan --version && \
+	conan install . && \
+	conan profile show default && \
+	cmake . && \
+	cmake --build .
 CMD ["./bin/awesomesauce"]


### PR DESCRIPTION
Previous Dockerfile used multiple 'RUN' commands which unnecessarily created many layers. Each 'RUN' command creates a layer, so we should only be running it once. 

(see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers and look for the heading *Minimize the number of layers*)