### PR TITLE
[Minor] Fixing bottom of the page links in .md files.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -173,4 +173,4 @@ server my_server{server::accept_policy_cb{&reject_all_connections}};
  
 ----
 
-### < [Prev—TLS/HTTPS](https.html) | [Next—Using the project template](template.html) >
+### < [Prev—TLS/HTTPS](https.md) | [Next—Using the project template](template.md) >

--- a/docs/https.md
+++ b/docs/https.md
@@ -61,4 +61,4 @@ assets—the server certificate and private key—even simpler. Watch this space
 
 ----
 
-### < [Prev—Serving static assets](static_assets.html) | [Next—Configuration reference](configuration.html) >
+### < [Prev—Serving static assets](static_assets.md) | [Next—Configuration reference](configuration.md) >

--- a/docs/regexes.md
+++ b/docs/regexes.md
@@ -38,4 +38,4 @@ router->handle_request(request_method::GET,
 
 ----
 
-### < [Prev—Simple API endpoints](simple_api_endpoint.html) | [Next—Serving static assets](static_assets.html) >
+### < [Prev—Simple API endpoints](simple_api_endpoint.md) | [Next—Serving static assets](static_assets.md) >

--- a/docs/simple_api_endpoint.md
+++ b/docs/simple_api_endpoint.md
@@ -170,4 +170,4 @@ If you want to return a custom response header, you can include that in the resp
 
 ----
 
-### < [Prev—Getting started](using.html) | [Next—Defining endpoints with regexs](regexes.html) >
+### < [Prev—Getting started](using.md) | [Next—Defining endpoints with regexs](regexes.md) >

--- a/docs/static_assets.md
+++ b/docs/static_assets.md
@@ -3,7 +3,7 @@ layout: default
 title: Serving static assets
 ---
 
-# {{ page.title }}
+# Serving static assets
 
 In addition to all the lovely dynamic content you want to serve up, you might well also have some static file that require serving as well—stylesheets, JavaScript, web fonts, images, and so on. Luna, naturally, can help you.
 
@@ -77,4 +77,4 @@ int main(void)
 
 ----
 
-### < [Prev—Defining endpoints with regexs](regexes.html) | [Next—TLS/HTTPS](https.html) >
+### < [Prev—Defining endpoints with regexs](regexes.md) | [Next—TLS/HTTPS](https.md) >

--- a/docs/template.md
+++ b/docs/template.md
@@ -70,4 +70,4 @@ Now visit [http://localhost:8080](http://localhost:8080) to see the app in actio
 
 ----
 
-### < [Prev—Configuration reference](configuration.html)
+### < [Prev—Configuration reference](configuration.md)

--- a/docs/using.md
+++ b/docs/using.md
@@ -112,4 +112,4 @@ In the next section, we'll look at how the code that drives this page works, so 
 
 ----
 
-### < [Prev—Home](index.html) | [Next—Simple API endpoints](simple_api_endpoint.html) >
+### < [Prev—Home](index.md) | [Next—Simple API endpoints](simple_api_endpoint.md) >


### PR DESCRIPTION
Fixing bottom of the page links in .md files that are used for jumping to the next Markdown. Apparently, the links refer to .html files while the actual files in the repo are .md leading to a broken experience when browsing the Luna documentation.

Also, fix a minor title issue in static_assets.md.